### PR TITLE
fix: activate already created shell

### DIFF
--- a/src/poetry_plugin_shell/command.py
+++ b/src/poetry_plugin_shell/command.py
@@ -34,6 +34,13 @@ If a virtual environment does not exist, it will be created.
                 f"Virtual environment already activated: <info>{self.env.path}</>"
             )
 
+            # Activate the shell.
+            env = self.env
+            assert env.is_venv()
+            env = cast("VirtualEnv", env)
+            shell = Shell.get()
+            shell.activate(env)
+
             return 0
 
         self.line(f"Spawning shell within <info>{self.env.path}</>")


### PR DESCRIPTION
## Summary

> - When the shell is not yet created, it will create the shell then activate right away.
>   - However, when the shell is already created, it will not activate the shell right away, it will just print a message `Virtual environment already activated`.

<br />
<br />
<br />


## Changed

> - Once the shell is already created, activate it right away.

<br />
<br />
<br />


## Test Plan

> - Create shell.
> - Deactivate the shell.
> - Create/activate the same shell.
>   - It should activate the shell right away, instead of just printing the message.