### PR TITLE
fix: "already activated" message but shell is not active

### DIFF
--- a/src/poetry_plugin_shell/command.py
+++ b/src/poetry_plugin_shell/command.py
@@ -28,6 +28,9 @@ If a virtual environment does not exist, it will be created.
     def handle(self) -> int:
         from poetry_plugin_shell.shell import Shell
 
+        if os.environ.get("POETRY_ACTIVE") == "1" and not os.environ.get("VIRTUAL_ENV"):
+            os.environ.pop("POETRY_ACTIVE")
+
         # Check if it's already activated or doesn't exist and won't be created
         if self._is_venv_activated():
             self.line(
@@ -52,10 +55,6 @@ If a virtual environment does not exist, it will be created.
         return 0
 
     def _is_venv_activated(self) -> bool:
-        if os.environ.get("POETRY_ACTIVE") and not os.environ.get("VIRTUAL_ENV"):
-            os.environ.pop("POETRY_ACTIVE")
-            return False
-
         return bool(os.environ.get("POETRY_ACTIVE")) or getattr(
             sys, "real_prefix", sys.prefix
         ) == str(self.env.path)

--- a/src/poetry_plugin_shell/command.py
+++ b/src/poetry_plugin_shell/command.py
@@ -52,6 +52,10 @@ If a virtual environment does not exist, it will be created.
         return 0
 
     def _is_venv_activated(self) -> bool:
+        if os.environ.get("POETRY_ACTIVE") and not os.environ.get("VIRTUAL_ENV"):
+            os.environ.pop("POETRY_ACTIVE")
+            return False
+
         return bool(os.environ.get("POETRY_ACTIVE")) or getattr(
             sys, "real_prefix", sys.prefix
         ) == str(self.env.path)

--- a/tests/test_shell_command.py
+++ b/tests/test_shell_command.py
@@ -35,7 +35,9 @@ def test_shell(tester: CommandTester, mocker: MockerFixture) -> None:
 
 
 def test_shell_already_active(tester: CommandTester, mocker: MockerFixture) -> None:
+    assert isinstance(tester.command, ShellCommand)
     os.environ["POETRY_ACTIVE"] = "1"
+    os.environ["VIRTUAL_ENV"] = str(tester.command.env.path)
     shell_activate = mocker.patch("poetry_plugin_shell.shell.Shell.activate")
 
     tester.execute()

--- a/tests/test_shell_command.py
+++ b/tests/test_shell_command.py
@@ -52,6 +52,23 @@ def test_shell_already_active(tester: CommandTester, mocker: MockerFixture) -> N
     assert tester.status_code == 0
 
 
+def test_shell_stale_poetry_active(
+    tester: CommandTester, mocker: MockerFixture
+) -> None:
+    assert isinstance(tester.command, ShellCommand)
+    os.environ["POETRY_ACTIVE"] = "1"
+    shell_activate = mocker.patch("poetry_plugin_shell.shell.Shell.activate")
+
+    tester.execute()
+
+    assert isinstance(tester.command, ShellCommand)
+    expected_output = f"Spawning shell within {tester.command.env.path}\n"
+
+    shell_activate.assert_called_once_with(tester.command.env)
+    assert tester.io.fetch_output() == expected_output
+    assert tester.status_code == 0
+
+
 @pytest.mark.parametrize(
     ("poetry_active", "real_prefix", "prefix", "expected"),
     [


### PR DESCRIPTION
## Summary

> - Fixes #21 
> - If we have a newly created shell, then `deactivate`, then activate the shell again, it will only show a message that `Virtual environment already activated`, but its not activated.
>   - The problem is that we only check if the `POETRY_ACTIVE` is set, but not the `VIRTUAL_ENV`. 

<br />
<br />


## Changes 

> - `command.py`:
>   - If the `POETRY_ACTIVE` is set but not the __VIRTUAL_ENV__, pop the `POETRY_ACTIVE`.

<br />
<br />


## Test Plan

`Test 1`
> - Create shell.
> - Deactivate the shell.
> - Activate again the shell.
>   - It should activate the shell.

<br />

`Test 2`
> - Activate the shell.
> - Then, activate again.
>   - It should show `Virtual environment already activated`.