### PR TITLE
Handle missing virtualenv in shell command

### DIFF
--- a/src/poetry_plugin_shell/command.py
+++ b/src/poetry_plugin_shell/command.py
@@ -36,11 +36,19 @@ If a virtual environment does not exist, it will be created.
 
             return 0
 
-        self.line(f"Spawning shell within <info>{self.env.path}</>")
-
         # Be sure that we have the right type of environment.
         env = self.env
-        assert env.is_venv()
+        if not env.is_venv():
+            self.line_error(
+                "<error>Poetry could not find a virtual environment to activate.</>\n"
+                "If <info>virtualenvs.create</> is set to <comment>false</>, "
+                "enable virtual environment creation or create/select a virtual "
+                "environment before running <info>poetry shell</>."
+            )
+            return 1
+
+        self.line(f"Spawning shell within <info>{self.env.path}</>")
+
         env = cast("VirtualEnv", env)
 
         # Setting this to avoid spawning unnecessary nested shells

--- a/tests/test_shell_command.py
+++ b/tests/test_shell_command.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from poetry.utils.env import MockEnv
+
 from poetry_plugin_shell.command import ShellCommand
 
 
@@ -48,6 +50,25 @@ def test_shell_already_active(tester: CommandTester, mocker: MockerFixture) -> N
     shell_activate.assert_not_called()
     assert tester.io.fetch_output() == expected_output
     assert tester.status_code == 0
+
+
+def test_shell_without_virtualenv_shows_error(
+    command_tester_factory: CommandTesterFactory,
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    env = MockEnv(path=tmp_path / "system", is_venv=False)
+    tester = command_tester_factory("shell", environment=env)
+    shell_activate = mocker.patch("poetry_plugin_shell.shell.Shell.activate")
+
+    tester.execute()
+
+    error = tester.io.fetch_error()
+    shell_activate.assert_not_called()
+    assert "Spawning shell" not in tester.io.fetch_output()
+    assert "could not find a virtual environment" in error
+    assert "virtualenvs.create" in error
+    assert tester.status_code == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #30.

This replaces the internal assertion when `poetry shell` is run without a virtualenv with a user-facing error. It also avoids printing the misleading `Spawning shell within ...` line before the environment type is validated.

Checks:
- `pytest tests/test_shell_command.py -q -n 0`
- `ruff check src/poetry_plugin_shell/command.py tests/test_shell_command.py`
- `ruff format --check src/poetry_plugin_shell/command.py tests/test_shell_command.py`
- `pre-commit run --all-files`
