### PR TITLE
chore: prepare for Ruff 0.16

### DIFF
--- a/src/poetry_plugin_shell/shell.py
+++ b/src/poetry_plugin_shell/shell.py
@@ -90,7 +90,7 @@ class Shell:
                 args = ["/K", str(activate_path)]
 
             if args:
-                completed_proc = subprocess.run([self.path, *args])
+                completed_proc = subprocess.run([self.path, *args], check=False)
                 return completed_proc.returncode
             else:
                 # If no args are set, execute the shell within the venv

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,8 +211,8 @@ def project_factory(
 
         if install_deps:
             for deps in [dependencies, dev_dependencies]:
-                for name, version in deps.items():
-                    pkg = Package(name, version)
+                for dependency_name, version in deps.items():
+                    pkg = Package(dependency_name, version)
                     repo.add_package(pkg)
                     installed.add_package(pkg)
 


### PR DESCRIPTION
## Description

Prepare the source tree for the Ruff 0.16 default-rule expansion used by #59:

- make the intentional unchecked shell subprocess explicit while preserving its return-code handling
- avoid shadowing the project factory's `name` parameter while installing fixture dependencies

With these two changes, Ruff 0.16.1 checks the full tree successfully without changing runtime behavior.

## Related Issues

- Unblocks #59.

## Checklist

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic convention.

## Additional Comments

Validation:

- `ruff 0.16.1 check .` — passed
- `ruff 0.16.1 format --check .` — passed
- `pytest -q` — 17 passed
- `git diff --check` — passed